### PR TITLE
Document removeComments can cause SSR / React hydration issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Most of the options are disabled by default.
 | `processScripts`               | Array of strings corresponding to types of script elements to process through minifier (e.g. `text/ng-template`, `text/x-handlebars-template`, etc.) | `[ ]` |
 | `quoteCharacter`               | Type of quote to use for attribute values (' or ") | |
 | `removeAttributeQuotes`        | [Remove quotes around attributes when possible](http://perfectionkills.com/experimenting-with-html-minifier/#remove_attribute_quotes) | `false` |
-| `removeComments`               | [Strip HTML comments](http://perfectionkills.com/experimenting-with-html-minifier/#remove_comments). Note: removing comments from some frameworks (React) Server-side-rendering output can lead to hydration problems ([details](https://github.com/terser/html-minifier-terser/pull/85)) | `false` |
+| `removeComments`               | [Strip HTML comments](http://perfectionkills.com/experimenting-with-html-minifier/#remove_comments). Note: removing comments from some frameworks (React) Server-Side-Rendering output can lead to hydration problems ([details](https://github.com/terser/html-minifier-terser/pull/87)). | `false` |
 | `removeEmptyAttributes`        | [Remove all attributes with whitespace-only values](http://perfectionkills.com/experimenting-with-html-minifier/#remove_empty_or_blank_attributes) | `false` (could be `true`, `Function(attrName, tag)`) |
 | `removeEmptyElements`          | [Remove all elements with empty contents](http://perfectionkills.com/experimenting-with-html-minifier/#remove_empty_elements) | `false` |
 | `removeOptionalTags`           | [Remove optional tags](http://perfectionkills.com/experimenting-with-html-minifier/#remove_optional_tags) | `false` |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Most of the options are disabled by default.
 | `processScripts`               | Array of strings corresponding to types of script elements to process through minifier (e.g. `text/ng-template`, `text/x-handlebars-template`, etc.) | `[ ]` |
 | `quoteCharacter`               | Type of quote to use for attribute values (' or ") | |
 | `removeAttributeQuotes`        | [Remove quotes around attributes when possible](http://perfectionkills.com/experimenting-with-html-minifier/#remove_attribute_quotes) | `false` |
-| `removeComments`               | [Strip HTML comments](http://perfectionkills.com/experimenting-with-html-minifier/#remove_comments) | `false` |
+| `removeComments`               | [Strip HTML comments](http://perfectionkills.com/experimenting-with-html-minifier/#remove_comments). Note: removing comments from some frameworks (React) Server-side-rendering output can lead to hydration problems ([details](https://github.com/terser/html-minifier-terser/pull/85)) | `false` |
 | `removeEmptyAttributes`        | [Remove all attributes with whitespace-only values](http://perfectionkills.com/experimenting-with-html-minifier/#remove_empty_or_blank_attributes) | `false` (could be `true`, `Function(attrName, tag)`) |
 | `removeEmptyElements`          | [Remove all elements with empty contents](http://perfectionkills.com/experimenting-with-html-minifier/#remove_empty_elements) | `false` |
 | `removeOptionalTags`           | [Remove optional tags](http://perfectionkills.com/experimenting-with-html-minifier/#remove_optional_tags) | `false` |


### PR DESCRIPTION
For React sites using server-side rendering and client-side hydration, using the `removeComments` option can lead to hydration problems.

The original React SSR output is:

```html
<div id="__docusaurus">
   <span>
      Built using the<!-- --> <a href="https://www.electronjs.org/" target="_blank">Electron</a> <!-- -->, 
      based on<!-- --> <a href="https://www.chromium.org/" target="_blank">Chromium</a>
   </span>
</div>
```

It is optimized into:

```html 
<div id="__docusaurus">
   <span>Built using the <a href="https://www.electronjs.org/" target="_blank">Electron</a> , 
   based on <a href="https://www.chromium.org/" target="_blank">Chromium</a>
</div>
```

Removing those comments in the SSR HTML leads to both links having `href="https://www.chromium.org/"` after React hydration.

![image](https://user-images.githubusercontent.com/749374/135505430-1c51f60e-0402-42fa-8052-d47da4efce55.png)

---

This lib is agnostic but React is quite widely used and this bug is a bit nasty to pin down. 

I find it valuable to document it for others but I understand if you want to close this PR (at least it will be searchable).

---

Refs:
- https://github.com/facebook/docusaurus/pull/5629
- https://twitter.com/dan_abramov/status/1443628592097898498
