### PR TITLE
Release v7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-minifier-terser",
-  "version": "7.0.0-beta.0",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "html-minifier-terser",
-      "version": "7.0.0-beta.0",
+      "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
         "camel-case": "^4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "vite": "^3.0.7"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": "^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "uglify"
   ],
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": "^14.13.1 || >=16.0.0"
   },
   "type": "module",
   "main": "./dist/htmlminifier.cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "html-minifier-terser",
   "description": "Highly configurable, well-tested, JavaScript-based HTML minifier.",
-  "version": "7.0.0-beta.0",
+  "version": "7.0.0",
   "license": "MIT",
   "repository": "https://github.com/terser/html-minifier-terser.git",
   "bugs": "https://github.com/terser/html-minifier-terser/issues",


### PR DESCRIPTION
v7 pre-release is out there for quite a while and has no issues reported yet. Lets ship v7 stable.


### Breaking changes since v6

- Migrated build tool from `browserify` to `rollup`
- Replaced dependency `he` with `entities`
- ESM supported and re-write
- Several dependencies updated to latest (no user facing breaking changes though)
- Minimum Required node versions v14.13.1 or (v16 or greater)

### Features

- supports async css minify
- exports both ESM and CJS modules