### PR TITLE
Fix crash for `script`, `style`, and `link` tags with no-value type attribute

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -166,12 +166,12 @@ const keepScriptsMimetypes = new Set([
   'module'
 ]);
 
-function isScriptTypeAttribute(attrValue) {
+function isScriptTypeAttribute(attrValue = '') {
   attrValue = trimWhitespace(attrValue.split(/;/, 2)[0]).toLowerCase();
   return attrValue === '' || executableScriptsMimetypes.has(attrValue);
 }
 
-function keepScriptTypeAttribute(attrValue) {
+function keepScriptTypeAttribute(attrValue = '') {
   attrValue = trimWhitespace(attrValue.split(/;/, 2)[0]).toLowerCase();
   return keepScriptsMimetypes.has(attrValue);
 }
@@ -189,7 +189,7 @@ function isExecutableScript(tag, attrs) {
   return true;
 }
 
-function isStyleLinkTypeAttribute(attrValue) {
+function isStyleLinkTypeAttribute(attrValue = '') {
   attrValue = trimWhitespace(attrValue).toLowerCase();
   return attrValue === '' || attrValue === 'text/css';
 }

--- a/tests/minifier.spec.js
+++ b/tests/minifier.spec.js
@@ -1107,6 +1107,12 @@ test('removing javascript type attributes', async () => {
   output = '<script>alert(1)</script>';
   expect(await minify(input, { removeScriptTypeAttributes: true })).toBe(output);
 
+  // https://github.com/terser/html-minifier-terser/issues/132
+  input = '<script type>alert(1)</script>';
+  expect(await minify(input, { removeScriptTypeAttributes: false })).toBe(input);
+  output = '<script>alert(1)</script>';
+  expect(await minify(input, { removeScriptTypeAttributes: true })).toBe(output);
+
   input = '<script type="modules">alert(1)</script>';
   expect(await minify(input, { removeScriptTypeAttributes: false })).toBe(input);
   output = '<script type="modules">alert(1)</script>';
@@ -1138,6 +1144,12 @@ test('removing type="text/css" attributes', async () => {
   output = '<style>.foo { color: red }</style>';
   expect(await minify(input, { removeStyleLinkTypeAttributes: true })).toBe(output);
 
+  // https://github.com/terser/html-minifier-terser/issues/132
+  input = '<style type>.foo { color: red }</style>';
+  expect(await minify(input, { removeStyleLinkTypeAttributes: false })).toBe(input);
+  output = '<style>.foo { color: red }</style>';
+  expect(await minify(input, { removeStyleLinkTypeAttributes: true })).toBe(output);
+
   input = '<style type="text/css">.foo { color: red }</style>';
   expect(await minify(input, { removeStyleLinkTypeAttributes: false })).toBe(input);
   output = '<style>.foo { color: red }</style>';
@@ -1151,6 +1163,11 @@ test('removing type="text/css" attributes', async () => {
   expect(await minify(input, { removeStyleLinkTypeAttributes: true })).toBe(input);
 
   input = '<link rel="stylesheet" type="text/css" href="http://example.com">';
+  output = '<link rel="stylesheet" href="http://example.com">';
+  expect(await minify(input, { removeStyleLinkTypeAttributes: true })).toBe(output);
+
+  // https://github.com/terser/html-minifier-terser/issues/132
+  input = '<link rel="stylesheet" type href="http://example.com">';
   output = '<link rel="stylesheet" href="http://example.com">';
   expect(await minify(input, { removeStyleLinkTypeAttributes: true })).toBe(output);
 


### PR DESCRIPTION
Closes #132 