### PR TITLE
update clean-css 5.2.0 to ^5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "camel-case": "^4.1.2",
-    "clean-css": "5.2.0",
+    "clean-css": "^5.2.0",
     "commander": "^9.4.1",
     "entities": "^4.4.0",
     "param-case": "^3.0.4",


### PR DESCRIPTION
clean-css 5.2.0 has security issues. https://www.huntr.dev/bounties/6937a4ed-e41f-4fff-8f9b-8bcbed0f616e/ The issue is fixed in 5.2.2, please update to ^5.2.0 or 5.2.2.