### PR TITLE
Update `clean-css` To `v5.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "camel-case": "^4.1.2",
-        "clean-css": "5.2.0",
+        "clean-css": "~5.3.2",
         "commander": "^9.4.1",
         "entities": "^4.4.0",
         "param-case": "^3.0.4",
@@ -2752,9 +2752,9 @@
       "dev": true
     },
     "node_modules/clean-css": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.2.0.tgz",
-      "integrity": "sha512-2639sWGa43EMmG7fn8mdVuBSs6HuWaSor+ZPoFWzenBc6oN+td8YhTfghWXZ25G1NiiSvz8bOFBS7PdSbTiqEA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
+      "integrity": "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==",
       "dependencies": {
         "source-map": "~0.6.0"
       },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "camel-case": "^4.1.2",
-    "clean-css": "5.2.0",
+    "clean-css": "~5.3.2",
     "commander": "^9.4.1",
     "entities": "^4.4.0",
     "param-case": "^3.0.4",

--- a/tests/minifier.spec.js
+++ b/tests/minifier.spec.js
@@ -3426,7 +3426,7 @@ test('decode entity characters', async () => {
   output = '<div style="font:&quot">foo&dollar;</div>';
   expect(await minify(input, { minifyCSS: true })).toBe(output);
   expect(await minify(input, { decodeEntities: false, minifyCSS: true })).toBe(output);
-  output = '<div style="font:monospace">foo$</div>';
+  output = '<div style=\'font:"monospace"\'>foo$</div>';
   expect(await minify(input, { decodeEntities: true, minifyCSS: true })).toBe(output);
 
   input = '<a href="/?foo=1&amp;bar=&lt;2&gt;">baz&lt;moo&gt;&copy;</a>';


### PR DESCRIPTION
Updates `clean-css` to the latest version. Updates a test to reflect the functionally identical but different output the latest version of `clean-css` produces.

Resolves https://github.com/terser/html-minifier-terser/issues/149.