### PR TITLE
Add missing boolean attributes

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -207,7 +207,7 @@ function isStyleSheet(tag, attrs) {
   return true;
 }
 
-const isSimpleBoolean = new Set(['allowfullscreen', 'async', 'autofocus', 'autoplay', 'checked', 'compact', 'controls', 'declare', 'default', 'defaultchecked', 'defaultmuted', 'defaultselected', 'defer', 'disabled', 'enabled', 'formnovalidate', 'hidden', 'indeterminate', 'inert', 'ismap', 'itemscope', 'loop', 'multiple', 'muted', 'nohref', 'noresize', 'noshade', 'novalidate', 'nowrap', 'open', 'pauseonexit', 'readonly', 'required', 'reversed', 'scoped', 'seamless', 'selected', 'sortable', 'truespeed', 'typemustmatch', 'visible']);
+const isSimpleBoolean = new Set(['allowfullscreen', 'async', 'autofocus', 'autoplay', 'checked', 'compact', 'controls', 'declare', 'default', 'defaultchecked', 'defaultmuted', 'defaultselected', 'defer', 'disabled', 'enabled', 'formnovalidate', 'hidden', 'indeterminate', 'inert', 'ismap', 'itemscope', 'loop', 'multiple', 'muted', 'nohref', 'nomodule', 'noresize', 'noshade', 'novalidate', 'nowrap', 'open', 'pauseonexit', 'playsinline', 'readonly', 'required', 'reversed', 'scoped', 'seamless', 'selected', 'sortable', 'truespeed', 'typemustmatch', 'visible']);
 const isBooleanValue = new Set(['true', 'false']);
 
 function isBooleanAttribute(attrName, attrValue) {


### PR DESCRIPTION
These are boolean attributes, as referenced in the spec:

- [nomodule](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-nomodule)
- [playsinline](https://html.spec.whatwg.org/multipage/media.html#attr-video-playsinline)

Otherwise, they won’t collapse, as rendered by [online version](https://terser.org/html-minifier-terser/):

```html
<script nomodule="nomodule"></script>
<video playsinline="playsinline">
<input disabled="disabled">

<script nomodule=nomodule></script>
<video playsinline=playsinline>
<input disabled>
```