### PR TITLE
Replace `is-ci` with `ci-info`.isCi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "camel-case": "^4.1.2",
+        "ci-info": "^4.1.0",
         "clean-css": "~5.3.2",
         "commander": "^10.0.0",
         "entities": "^4.4.0",
@@ -32,7 +33,6 @@
         "eslint": "^8.44.0",
         "eslint-config-standard": "^17.1.0",
         "husky": "^8.0.3",
-        "is-ci": "^3.0.1",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "lint-staged": "^13.2.3",
@@ -1534,6 +1534,22 @@
         }
       }
     },
+    "node_modules/@jest/core/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.5.0.tgz",
@@ -2802,16 +2818,16 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
-      "dev": true,
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
+      "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/sibiraj-s"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4805,18 +4821,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-ci": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-      "dev": true,
-      "dependencies": {
-        "ci-info": "^3.2.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
-      }
-    },
     "node_modules/is-core-module": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
@@ -5322,6 +5326,22 @@
         }
       }
     },
+    "node_modules/jest-config/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jest-config/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5718,6 +5738,22 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-validate": {

--- a/package.json
+++ b/package.json
@@ -71,10 +71,11 @@
     "serve": "vite",
     "build:docs": "vite build --base /html-minifier-terser/",
     "lint": "eslint . --ignore-path .gitignore",
-    "prepare": "is-ci || husky install"
+    "prepare": "node -e 'process.exit(require(`ci-info`).isCI ? 0 : 1)' || husky install"
   },
   "dependencies": {
     "camel-case": "^4.1.2",
+    "ci-info": "^4.1.0",
     "clean-css": "~5.3.2",
     "commander": "^10.0.0",
     "entities": "^4.4.0",
@@ -94,7 +95,6 @@
     "eslint": "^8.44.0",
     "eslint-config-standard": "^17.1.0",
     "husky": "^8.0.3",
-    "is-ci": "^3.0.1",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "lint-staged": "^13.2.3",


### PR DESCRIPTION
Additional details
[is-ci just imports the underlying ci-info package and exports a single field](https://github.com/watson/is-ci/blob/master/index.js). We might as well just use that package instead and save ourselves (/NPM) the extra lookup and bandwidth (4kB).

![image](https://github.com/user-attachments/assets/c707d516-3604-476d-b599-b7df54d14b8c)

This PR saves about 3kB per install *for developers*, and two HTTP call to NPMs API.