### PR TITLE
Fix attribute quoting around ignored fragments

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -738,7 +738,7 @@ async function normalizeAttr(attr, attrs, tag, options) {
   };
 }
 
-function buildAttr(normalized, hasUnarySlash, options, isLast, uidAttr) {
+function buildAttr(normalized, hasUnarySlash, options, isLast, uidAttr, restoreIgnored) {
   const attrName = normalized.name;
   let attrValue = normalized.value;
   const attr = normalized.attr;
@@ -752,8 +752,11 @@ function buildAttr(normalized, hasUnarySlash, options, isLast, uidAttr) {
   ) {
     if (!options.preventAttributesEscaping) {
       if (typeof options.quoteCharacter === 'undefined') {
-        const apos = (attrValue.match(/'/g) || []).length;
-        const quot = (attrValue.match(/"/g) || []).length;
+        // ignored fragments are put back verbatim once minification is done, so
+        // the quotes inside them cannot be escaped and have to be counted here
+        const quoted = restoreIgnored ? restoreIgnored(attrValue) : attrValue;
+        const apos = (quoted.match(/'/g) || []).length;
+        const quot = (quoted.match(/"/g) || []).length;
         attrQuote = apos < quot ? "'" : '"';
       } else {
         attrQuote = options.quoteCharacter === "'" ? "'" : '"';
@@ -1119,6 +1122,14 @@ async function minifyHTML(value, options, partialMarkup) {
     await createSortFns(value, options, uidIgnore, uidAttr);
   }
 
+  function restoreIgnoredFragments(str) {
+    return uidPattern
+      ? str.replace(uidPattern, function (match, prefix, index) {
+          return ignoredCustomMarkupChunks[+index][0];
+        })
+      : str;
+  }
+
   function _canCollapseWhitespace(tag, attrs) {
     return options.canCollapseWhitespace(tag, attrs, canCollapseWhitespace);
   }
@@ -1243,7 +1254,7 @@ async function minifyHTML(value, options, partialMarkup) {
       for (let i = attrs.length, isLast = true; --i >= 0; ) {
         const normalized = await normalizeAttr(attrs[i], attrs, tag, options);
         if (normalized) {
-          parts.unshift(buildAttr(normalized, hasUnarySlash, options, isLast, uidAttr));
+          parts.unshift(buildAttr(normalized, hasUnarySlash, options, isLast, uidAttr, restoreIgnoredFragments));
           isLast = false;
         }
       }

--- a/tests/minifier.spec.js
+++ b/tests/minifier.spec.js
@@ -2073,7 +2073,7 @@ test('Ignore custom fragments', async () => {
   expect(await minify(input, { ignoreCustomFragments: reFragments })).toBe(input);
 
   input = '<img src="{% static "images/logo.png" %}">';
-  output = '<img src="{% static "images/logo.png" %}">';
+  output = '<img src=\'{% static "images/logo.png" %}\'>';
   expect(await minify(input, { ignoreCustomFragments: [/\{%[^%]*?%\}/g] })).toBe(output);
 
   input =
@@ -2263,6 +2263,16 @@ test('Ignore custom fragments', async () => {
   input = '<link href="<?php echo \'http://foo/\' ?>">';
   expect(await minify(input)).toBe(input);
   expect(await minify(input, { removeAttributeQuotes: true })).toBe(input);
+
+  input = '<link href=\'<?php echo "http://foo/" ?>\'>';
+  expect(await minify(input)).toBe(input);
+  expect(await minify(input, { removeAttributeQuotes: true })).toBe(input);
+
+  input = '<div title=\'a<?php echo "b" ?>c\'>x</div>';
+  expect(await minify(input)).toBe(input);
+
+  input = '<div title=\'a&#39;b<?php echo "c" ?>\'>x</div>';
+  expect(await minify(input)).toBe(input);
 
   input = '<pre>\nfoo\n<? bar ?>\nbaz\n</pre>';
   expect(await minify(input)).toBe(input);


### PR DESCRIPTION
`<?php ... ?>` and `<% ... %>` are in the default `ignoreCustomFragments`, so this needs no options at all:

```js
await minify(`<div title='<?php echo "x" ?>'>y</div>`);
// => <div title="<?php echo "x" ?>">y</div>
```

That output no longer parses — a browser reads `title="<?php echo "` followed by three junk attributes.

`buildAttr` picks the quote character by counting `'` and `"` in the attribute value, but ignored fragments are still placeholders at that point, so the quotes inside them aren't counted. Escaping afterwards isn't an option either: the fragment is restored verbatim at the very end, and escaping it would break the template. Expanding the placeholders before counting lets the existing heuristic pick a delimiter that actually works.

I had to change one existing expectation: `<img src="{% static "images/logo.png" %}">` now comes out single-quoted. The old output isn't parseable as a single attribute either, so I think that's part of the fix rather than a regression — happy to revert it if you'd rather keep it as is.

I found this diffing parse5 trees of input vs. output. Over a generated matrix of attribute delimiter × fragment content (1890 cases) 690 attributes came back corrupted before the change and 90 after; those remaining are a separate `minifyURLs` problem (it percent-encodes the tab wrapping the placeholder), which I left alone.

`test:node` and `test:web` both pass, lint and build are clean.
